### PR TITLE
Cana import

### DIFF
--- a/cubewalkers/parser.py
+++ b/cubewalkers/parser.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from curses.ascii import isdigit
 import cupy as cp
 from io import StringIO
 import re
@@ -175,7 +174,7 @@ def bnet2rawkernel(rules: str,
 def network_rules_from_cana(N: BooleanNetwork) -> str:
     """Transforms the prime implicants LUT of a Boolean Network from CANA to algebraic format.
 
-    Parameters
+    Parametershttps://github.com/rionbr/CANA
     ----------
     N : BooleanNetwork
         CANA Boolean network

--- a/cubewalkers/parser.py
+++ b/cubewalkers/parser.py
@@ -193,7 +193,7 @@ def network_rules_from_cana(N: BooleanNetwork) -> str:
         alg_rule += node_rule_from_cana(node=node, int2name=int2name)
         alg_rule += "\n"
     
-    return alg_rule
+    return alg_rule[:-1]
 
 def node_rule_from_cana(node: BooleanNode, int2name: dict = None) -> str:
     """Transforms the prime implicants LUT of a Boolean Node from CANA to algebraic format.
@@ -211,20 +211,19 @@ def node_rule_from_cana(node: BooleanNode, int2name: dict = None) -> str:
         Node rule in algebraic format.
         Ex.: A* = A|B&C
     """
-    
+    if int2name == None:
+        int2name = {i: "x{}".format(i) for i in node.inputs}
+        
     if node.constant:
-        return "{name}* = {state}".format(name=node.name, state=node.state)
+        return "{name}* = {state}".format(name=int2name[node.id], state=node.state)
     
     node._check_compute_canalization_variables(prime_implicants=True)
     
-    if int2name == None:
-        int2name = {i: "x{}".format(i) for i in node.inputs}
-    
     if node.bias() < 0.5:
-        alg_rule = "{name}* = ".format(name=node.name)
+        alg_rule = "{name}* = ".format(name=int2name[node.id])
         prime_rules = node._prime_implicants['1']
     else:
-        alg_rule = "{name}* = !(".format(name=node.name)
+        alg_rule = "{name}* = !(".format(name=int2name[node.id])
         prime_rules = node._prime_implicants['0']
     
     for rule in prime_rules:

--- a/cubewalkers/parser.py
+++ b/cubewalkers/parser.py
@@ -171,12 +171,12 @@ def bnet2rawkernel(rules: str,
 
     return cp.RawKernel(cpp_body, kernel_name), varnames, cpp_body
 
-def network_rules_from_cana(N: BooleanNetwork) -> str:
+def network_rules_from_cana(BN: BooleanNetwork) -> str:
     """Transforms the prime implicants LUT of a Boolean Network from CANA to algebraic format.
 
-    Parametershttps://github.com/rionbr/CANA
+    Parameters: https://github.com/rionbr/CANA
     ----------
-    N : BooleanNetwork
+    BN : BooleanNetwork
         CANA Boolean network
 
     Returns
@@ -187,21 +187,21 @@ def network_rules_from_cana(N: BooleanNetwork) -> str:
     """
     
     alg_rule = ""
-    int2name = {v: name_adjustment(k) for k, v in N.name2int.items()}
-    for node in N.nodes:
+    int2name = {v: name_adjustment(k) for k, v in BN.name2int.items()}
+    for node in BN.nodes:
         alg_rule += node_rule_from_cana(node=node, int2name=int2name)
         alg_rule += "\n"
     
     return alg_rule[:-1]
 
-def node_rule_from_cana(node: BooleanNode, int2name: dict = None) -> str:
+def node_rule_from_cana(node: BooleanNode, int2name: dict[int, str] | None = None) -> str:
     """Transforms the prime implicants LUT of a Boolean Node from CANA to algebraic format.
 
     Parameters
     ----------
     node : BooleanNode
         CANA Boolean node
-    int2name : dict, optional
+    int2name : dict[int, str], optional
         Dictionary with the node ids as keys and node name as values, by default None
 
     Returns

--- a/cubewalkers/parser.py
+++ b/cubewalkers/parser.py
@@ -174,10 +174,9 @@ def bnet2rawkernel(rules: str,
 def network_rules_from_cana(BN: BooleanNetwork) -> str:
     """Transforms the prime implicants LUT of a Boolean Network from CANA to algebraic format.
 
-    Parameters: https://github.com/rionbr/CANA
     ----------
     BN : BooleanNetwork
-        CANA Boolean network
+        CANA Boolean network. See: https://github.com/rionbr/CANA
 
     Returns
     -------
@@ -200,7 +199,7 @@ def node_rule_from_cana(node: BooleanNode, int2name: dict[int, str] | None = Non
     Parameters
     ----------
     node : BooleanNode
-        CANA Boolean node
+        CANA Boolean node. See: https://github.com/rionbr/CANA
     int2name : dict[int, str], optional
         Dictionary with the node ids as keys and node name as values, by default None
 

--- a/cubewalkers/simulation.py
+++ b/cubewalkers/simulation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import cupy as cp
 from cubewalkers.update_schemes import synchronous, asynchronous
 
+import cubewalkers as cw
 
 def simulate_ensemble(kernel: cp.RawKernel,
                       N: int, T: int, W: int,
@@ -141,3 +142,57 @@ def dynamical_impact(kernel: cp.RawKernel, source: int | list[int],
         impact[t+1] = cp.mean(outU ^ outP, axis = 1)
     
     return impact
+
+
+def derrida_coefficient(kernel: cp.RawKernel,
+                     N: int, W: int,
+                     maskfunction: callable = synchronous,
+                     threads_per_block: tuple[int, int] = (16, 16)) -> float:
+    """Computes the derrida coefficient.
+
+    Parameters
+    ----------
+    kernel : cp.RawKernel
+        CuPy RawKernel that provides the update functions (see parser module).
+    N : int
+        Number of nodes in the network.
+    W : int
+        Number of ensemble walkers to simulate.
+    maskfunction : callable, optional
+        Function that returns a mask for selecting which node values to update. 
+        By default, uses the synchronous update scheme. See update_schemes for examples.
+        For dynamical impact, if the maskfunction is state-dependent, then the unperturbed
+        trajectory is used.
+    threads_per_block : tuple[int, int], optional
+        How many threads should be in each block for each dimension of the N x W array, 
+        by default (16, 16). See CUDA documentation for details.
+
+    Returns
+    -------
+    float
+        Derrida coefficient
+    """
+    # compute blocks per grid based on number of walkers & variables and threads_per_block
+    blocks_per_grid = (W // threads_per_block[1]+1,
+                       N // threads_per_block[0]+1)
+    
+    # initial conditions
+    #outU = cp.random.choice([cp.bool_(0), cp.bool_(1)], (N, W))
+    outU = cp.around(cp.random.random((N,W))).astype(cp.bool_)
+    outP = outU.copy()
+    #perturbed_var = cp.random.choice(range(N), W)
+    perturbed_var = cp.random.randint(N, size=W)
+    for idx, var in enumerate(perturbed_var):
+        outP[var, idx] = ~outP[var, idx]
+    
+    # get values from update
+    arrU = outU.copy()  # get values from update
+    arrP = outP.copy()
+    
+    mask = maskfunction(1, N, W, arrU)
+    
+    # run the update on the GPU for the two states
+    kernel(blocks_per_grid, threads_per_block, (arrU, mask, outU, 1, N, W))
+    kernel(blocks_per_grid, threads_per_block, (arrP, mask, outP, 1, N, W))    
+    
+    return cp.mean(outU ^ outP)

--- a/cubewalkers/tests/test_cana_import.py
+++ b/cubewalkers/tests/test_cana_import.py
@@ -1,0 +1,20 @@
+# Cubewalkers import
+from cubewalkers import parser as cwp 
+
+# CANA import
+import cana.boolean_network as cana_bn
+
+
+## Feed-Forwward motif with NOT+AND
+logic = {0: {'name': '3A', 'in':[], 'out':[0]},
+         1: {'name': 'B+', 'in':[0], 'out':[1, 0]},
+         2: {'name': '(C)', 'in':[0, 1], 'out':[0, 0, 0, 1]}}
+
+cw_rules = "number_3A* = 0\nB_plus_* = !(number_3A)\n_C_* = number_3A&B_plus_"
+
+def test_cana_import():
+    
+    BN = cana_bn.BooleanNetwork.from_dict(logic)
+    cana_rules = cwp.network_rules_from_cana(BN)
+    
+    assert(cana_rules == cw_rules)

--- a/cubewalkers/tests/test_cana_import.py
+++ b/cubewalkers/tests/test_cana_import.py
@@ -1,10 +1,6 @@
 # Cubewalkers import
 from cubewalkers import parser as cwp 
 
-# CANA import
-import cana.boolean_network as cana_bn
-
-
 ## Feed-Forwward motif with NOT+AND
 logic = {0: {'name': '3A', 'in':[], 'out':[0]},
          1: {'name': 'B+', 'in':[0], 'out':[1, 0]},
@@ -13,6 +9,9 @@ logic = {0: {'name': '3A', 'in':[], 'out':[0]},
 cw_rules = "number_3A* = 0\nB_plus_* = !(number_3A)\n_C_* = number_3A&B_plus_"
 
 def test_cana_import():
+    
+    # CANA import
+    import cana.boolean_network as cana_bn
     
     BN = cana_bn.BooleanNetwork.from_dict(logic)
     cana_rules = cwp.network_rules_from_cana(BN)


### PR DESCRIPTION
Added to parser.py the functions to import rules form cana.
- network_rules_from_cana takes a BooleanNetwork
- node_rule_from_cana takes a BooleanNode
Also in there is a function to correct the node names with the exceptions: ["-", ")", "(", "/", "\\", "+"] and if the first digit is a number. Further additions to the exceptions can be made, but I'll leave this discussion to issue #15 

@troonmel You'll need to install CANA from https://github.com/rionbr/CANA in order for the test function for it to work on your end.